### PR TITLE
Fix typo in example and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Xtor: An handler async actor framework.
+
 [![CI](https://github.com/starcoinorg/xtor/actions/workflows/rust.yml/badge.svg)](https://github.com/starcoinorg/xtor/actions/workflows/rust.yml)
 [![Crates](https://img.shields.io/crates/v/xtor)](https://crates.io/crates/xtor)
+
 ## Key features
+
 - small: very small codebase
 - async: allow you to write async code in your actor
 - full featured: we have built-in types such as `Supervisor` `Broker` `Caller` and so on
@@ -10,19 +13,21 @@
 ## usage
 
 add `xtor` to your library
+
 ```
 cargo add xtor
 ```
 
 write some code
+
 ```rs
 use anyhow::Result;
 use async_trait::async_trait;
 use xtor::actor::{context::Context, message::Handler, runner::Actor};
 
 // first define actor
-struct HelloAector;
-impl Actor for HelloAector {}
+struct HelloActor;
+impl Actor for HelloActor {}
 
 // then define message
 #[xtor::message(result = "()")]
@@ -31,7 +36,7 @@ struct Hello;
 
 // then impl the handler
 #[async_trait]
-impl Handler<Hello> for HelloAector {
+impl Handler<Hello> for HelloActor {
     async fn handle(&self, _ctx: &Context, msg: Hello) -> Result<()> {
         println!("{:?} received", &msg);
         Ok(())
@@ -41,22 +46,22 @@ impl Handler<Hello> for HelloAector {
 // main will finish when all actors died out.
 #[xtor::main]
 async fn main() -> Result<()> {
-    let hello_actor = HelloAector;
+    let hello_actor = HelloActor;
     let hello_actor_address = hello_actor.spawn().await?;
-    hello_actor_address.call::<HelloAector, Hello>(Hello).await
+    hello_actor_address.call::<HelloActor, Hello>(Hello).await
 }
 ```
 
-
 ## project structure
+
 - `src/actor/*` for pure async actor implementation
 - `src/utils/*` for utilities both trait and default implementation such as
   - `DefaultBroker`
   - `DefaultSupervisor`
   - `Service`
 
-
 ## References
+
 - [Actix](https://github.com/actix/actix)
 - [Xactor](https://github.dev/sunli829/xactor)
 - [Tokio](https://github.com/tokio-rs/tokio)

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use xtor::actor::{context::Context, message::Handler, runner::Actor};
 
 // first define actor
-struct HelloAector;
-impl Actor for HelloAector {}
+struct HelloActor;
+impl Actor for HelloActor {}
 
 // then define message
 #[xtor::message(result = "()")]
@@ -13,7 +13,7 @@ struct Hello;
 
 // then impl the handler
 #[async_trait]
-impl Handler<Hello> for HelloAector {
+impl Handler<Hello> for HelloActor {
     async fn handle(&self, _ctx: &Context, msg: Hello) -> Result<()> {
         println!("{:?} received", &msg);
         Ok(())
@@ -23,7 +23,7 @@ impl Handler<Hello> for HelloAector {
 // main will finish when all actors died out.
 #[xtor::main]
 async fn main() -> Result<()> {
-    let hello_actor = HelloAector;
+    let hello_actor = HelloActor;
     let hello_actor_address = hello_actor.spawn().await?;
-    hello_actor_address.call::<HelloAector, Hello>(Hello).await
+    hello_actor_address.call::<HelloActor, Hello>(Hello).await
 }

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use tracing::info;
 use xtor::actor::{context::Context, message::Handler, runner::Actor};
 // first define actor
-struct HelloAector;
-impl Actor for HelloAector {}
+struct HelloActor;
+impl Actor for HelloActor {}
 
 // then define message
 #[xtor::message(result = "()")]
@@ -13,10 +13,10 @@ struct Hello;
 
 // then impl the handler
 #[async_trait]
-impl Handler<Hello> for HelloAector {
+impl Handler<Hello> for HelloActor {
     #[tracing::instrument(
         skip(self,_ctx),
-        name = "HelloAector::Hello",
+        name = "HelloActor::Hello",
         fields(addr = self.get_name_or_id_string(_ctx).as_str())
     )]
     async fn handle(&self, _ctx: &Context, msg: Hello) -> Result<()> {
@@ -29,7 +29,7 @@ impl Handler<Hello> for HelloAector {
 #[xtor::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    let hello_actor = HelloAector;
+    let hello_actor = HelloActor;
     let hello_actor_address = hello_actor.spawn().await?;
-    hello_actor_address.call::<HelloAector, Hello>(Hello).await
+    hello_actor_address.call::<HelloActor, Hello>(Hello).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 //! use xtor::actor::{context::Context, message::Handler, runner::Actor};
 //!
 //! // first define actor
-//! struct HelloAector;
-//! impl Actor for HelloAector {}
+//! struct HelloActor;
+//! impl Actor for HelloActor {}
 //!
 //! // then define message
 //! #[xtor::message(result = "()")]
@@ -31,7 +31,7 @@
 //!
 //! // then impl the handler
 //! #[async_trait]
-//! impl Handler<Hello> for HelloAector {
+//! impl Handler<Hello> for HelloActor {
 //!     async fn handle(&self, _ctx: &Context, msg: Hello) -> Result<()> {
 //!         println!("{:?} received", &msg);
 //!         Ok(())
@@ -41,9 +41,9 @@
 //! // main will finish when all actors died out.
 //! #[xtor::main]
 //! async fn main() -> Result<()> {
-//!     let hello_actor = HelloAector;
+//!     let hello_actor = HelloActor;
 //!     let hello_actor_address = hello_actor.spawn().await?;
-//!     hello_actor_address.call::<HelloAector, Hello>(Hello).await
+//!     hello_actor_address.call::<HelloActor, Hello>(Hello).await
 //! }
 //! ```
 //!


### PR DESCRIPTION
This PR change the miss spelling `HelloAector` to `HelloActor`.
