### PR TITLE
Replace `lazy_static` with `std::lazy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ description = "Async Actor framework for Rust which is blazing fast and rock sol
 [dependencies]
 tokio = {version = "^1", features = ["full"]}
 async-trait = "0.1"
-once_cell = "1.5"
 anyhow = { version = "1" }
 futures = "0.3"
-lazy_static = "1"
 dashmap = "5.2"
 xtor_derive = {version = "0.9", path = "xtor_derive"}
 tracing = "0.1"
@@ -25,6 +23,7 @@ tracing = "0.1"
 # bench marks and tests
 [dev-dependencies]
 criterion = {version = "0.3.2", features = ["html_reports"]}
+once_cell = "1.5"
 actix = "0.13.0"
 async-trait = "0.1.24"
 tokio-test = "0.4.2"

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -1,7 +1,8 @@
+use std::sync::atomic::AtomicUsize;
+
 use anyhow::Result;
 use futures::{join, try_join};
 use once_cell::sync::OnceCell;
-use std::sync::atomic::AtomicUsize;
 use tracing::info;
 use xtor::actor::{addr::WeakAddr, context::Context, message::Handler, runner::Actor};
 

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,7 +1,8 @@
-use anyhow::Result;
 use std::sync::atomic::AtomicUsize;
+
+use anyhow::Result;
 use tracing::info;
-use xtor::actor::{context::Context, message::Handler, runner::Actor};
+use xtor::actor::{message::Handler, runner::Actor};
 
 #[xtor::message(result = "()")]
 struct AddOne;

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -1,11 +1,13 @@
-use std::sync::{Arc, Weak};
+use std::{
+    lazy::SyncOnceCell,
+    sync::{Arc, Weak},
+};
 
 use futures::{
     channel::{mpsc, oneshot},
     future::{join_all, Shared},
     lock::Mutex,
 };
-use once_cell::sync::OnceCell;
 
 use super::{
     addr::{Event, WeakAddr},
@@ -20,7 +22,7 @@ pub struct Context {
     tx: Weak<mpsc::UnboundedSender<Event>>,
     pub(crate) rx_exit: Shared<oneshot::Receiver<()>>,
     pub(crate) supervisors: Mutex<Vec<Proxy<Restart>>>,
-    pub(crate) addr: OnceCell<WeakAddr>,
+    pub(crate) addr: SyncOnceCell<WeakAddr>,
 }
 
 unsafe impl Send for Context {}
@@ -44,7 +46,7 @@ impl Context {
                 tx: weak_tx,
                 rx_exit,
                 supervisors: Mutex::new(vec![]),
-                addr: OnceCell::new(),
+                addr: SyncOnceCell::new(),
             },
             rx,
             tx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 //! ## Key features
 //! - small: very small codebase
 //! - async: allow you to write async code in your actor
-//! - full featured: we have built-in types such as `Supervisor` `Broker` `Caller` and so on
+//! - full featured: we have built-in types such as `Supervisor` `Broker`
+//!   `Caller` and so on
 //! - both dynamic and fast: typed message and weak typed event.
 //!
 //! ## usage
@@ -49,20 +50,17 @@
 //!
 //! ## More Examples?
 //! please take a look at the examples folder in the [repository](https://github.com/starcoinorg/xtor).
-//!
 
 #![feature(type_name_of_val)]
+#![feature(once_cell)]
 
 use actor::runner::ACTOR_ID_HANDLE;
-
 use futures::Future;
 
 #[cfg(test)]
 mod tests;
 
-pub use xtor_derive::main;
-pub use xtor_derive::message;
-pub use xtor_derive::test;
+pub use xtor_derive::{main, message, test};
 
 /// the core of xtor
 pub mod actor;

--- a/src/utils/service.rs
+++ b/src/utils/service.rs
@@ -1,16 +1,13 @@
-use std::{any::TypeId, sync::Arc};
+use std::{any::TypeId, lazy::SyncLazy, sync::Arc};
 
 use anyhow::Result;
 use dashmap::DashMap;
-use lazy_static::lazy_static;
 
 use crate::actor::{addr::Addr, runner::Actor};
 
 pub type Registry = DashMap<TypeId, Arc<dyn Service>>;
 
-lazy_static! {
-    static ref GLOBAL_SERVICE_REGISTRY: Registry = DashMap::new();
-}
+pub static GLOBAL_SERVICE_REGISTRY: SyncLazy<Registry> = SyncLazy::new(DashMap::new);
 
 thread_local! {
     static LOCAL_SERVICE_REGISTRY: Registry = DashMap::new();


### PR DESCRIPTION
- feat: use once_cell instead of lazy_static

Note: This PR also introduces some minor formatting change due to lack of rustfmt.toml